### PR TITLE
Update RFC0007-Weak-Aliases.md

### DIFF
--- a/X-Rejected/RFC0007-Weak-Aliases.md
+++ b/X-Rejected/RFC0007-Weak-Aliases.md
@@ -113,19 +113,21 @@ Bruce Payette: Reject
 
 Steve Lee: Reject
 
+Hemant Mahawar: Absent
+
 ### Majority Decision
 
-The [feedback](https://github.com/PowerShell/PowerShell-RFC/issues/16) was extremely helpful as lead to some great discussion and insights.  After discussion of the RFC and the
-feedback with the PowerShell team, the committee voted unanimously to rejct this RFC,
+The [feedback](https://github.com/PowerShell/PowerShell-RFC/issues/16) was extremely helpful as lead to some great discussion and insights.
+After discussion of the RFC and the feedback with the PowerShell team, the committee voted unanimously to rejct this RFC,
 
-The Weak Alias RFC as it's currently written does not solve the overall problem with aliases that collide with existing tools.  Although it resolves some specific use cases, it
-introduces other problems which may lead to unpredictable and inconsistent results.  However, simply removing the aliases was deemed too risky a change for Windows PowerShell
-as it would break existing scripts that depend on the existing behavior.  The wget/curl aliases were already removed from the Open Source PowerShell on CoreCLR so the problem
-was limited to Windows PowerShell.
+The Weak Alias RFC as it's currently written does not solve the overall problem with aliases that collide with existing tools.
+Although it resolves some specific use cases, it introduces other problems which may lead to unpredictable and inconsistent results.
+However, simply removing the aliases was deemed too risky a change for Windows PowerShell as it would break existing scripts that depend on the existing behavior. 
+The wget/curl aliases were already removed from PowerShell Core so the problem was limited to Windows PowerShell.
 
-The PowerShell team have discussed several ideas to help mitigate this issue on Windows PowerShell and over time educate users to not rely on aliases in scripts.  PSScriptAnalyzer
-already contains a rule to discourage the use of aliases in scripts and more work may be done to enforce the rule.  A new RFC will be drafted introducing the capability for
-deprecation in PowerShell to inform users of potential future breaking changes.
+The PowerShell team have discussed several ideas to help mitigate this issue on Windows PowerShell and over time educate users to not rely on aliases in scripts.
+PSScriptAnalyzer already contains a rule to discourage the use of aliases in scripts and more work may be done to enforce the rule.
+A new RFC will be drafted introducing the capability for deprecation in PowerShell to inform users of potential future breaking changes.
 
 ### Minority Decision
 


### PR DESCRIPTION
Switched to semantic line feeds, 'PowerShell Core' terminology, and added Hemant as an absentee non-vote.
